### PR TITLE
Display notebooks properly

### DIFF
--- a/build_website.sh
+++ b/build_website.sh
@@ -49,16 +49,12 @@ function convert_tutorials {
   # remove the github repo utils so they don't end up in the website output
   rm .gitignore || true
   rm README.md || true
+  rm -r .git/ || true
 
-  for x in *.ipynb; do
-    jupyter-nbconvert --to html --template basic $x
-    rm $x
-  done
-  # remove any empty lines in the beginning of the converted files
-  # otherwise the yaml front-matter is not on line 1 and jekyll will not parse the file
-  for x in *.html; do
-    sed -i '/./,$!d' $x
-  done
+  ./convert_tutorials.py "."
+
+  rm *.ipynb
+
   cd -
 }
 

--- a/build_website.sh
+++ b/build_website.sh
@@ -51,12 +51,12 @@ function convert_tutorials {
   rm README.md || true
 
   for x in *.ipynb; do
-    jupyter-nbconvert --to markdown $x
+    jupyter-nbconvert --to html --template basic $x
     rm $x
   done
-  # remove any empty lines in the beginning of the markdown files
+  # remove any empty lines in the beginning of the converted files
   # otherwise the yaml front-matter is not on line 1 and jekyll will not parse the file
-  for x in *.md; do
+  for x in *.html; do
     sed -i '/./,$!d' $x
   done
   cd -

--- a/convert-tutorials.py
+++ b/convert-tutorials.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# coding=utf-8
+
+import os
+import argparse
+import subprocess
+import json
+import nbformat
+
+"""
+Iterate over readdy_documentation/_tutorials/*.ipynb,
+Convert them to basic html,
+Read metadata from ipynb and prepend to the html as yaml front matter.
+
+Metadata of the notebook should look like:
+
+"metadata": {
+    "readdy" : {
+         "title": "Internal API",
+         "category": "demonstration",
+         "position": "1"
+    },
+    ...
+}
+"""
+
+__license__ = "LGPL"
+__author__ = "chrisfroe"
+
+parser = argparse.ArgumentParser(description='Convert ipython notebooks to readdy_documentation - compatible html')
+parser.add_argument('notebook_dir', type=str, help='path to directory where .ipynb files are located')
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    notebook_dir = args.notebook_dir
+    os.chdir(notebook_dir)
+
+    for filename in os.listdir(os.getcwd()):
+        if filename.endswith(".ipynb"):
+            with open(filename, "r") as content_file:
+                json_string = content_file.read()
+            notebook = nbformat.reads(json_string, as_version=4)
+            subprocess.run("jupyter-nbconvert --to html --template basic " + filename, shell=True)
+            title = notebook.metadata.readdy.title
+            category = notebook.metadata.readdy.category
+            position = notebook.metadata.readdy.position
+            front_matter = "---\ntitle: " + title + "\ncategory: " + category + "\nposition: " + position + "\n---\n"
+            print("prepending the following front matter", front_matter)
+            filename_as_html = os.path.splitext(filename)[0]+'.html'
+            with open(filename_as_html, "r") as content_file:
+                origin = content_file.read()
+
+            with open(filename_as_html, "w") as content_file:
+                content_file.write(front_matter + origin)

--- a/convert_tutorials.py
+++ b/convert_tutorials.py
@@ -45,8 +45,8 @@ if __name__ == "__main__":
             category = notebook.metadata.readdy.category
             position = notebook.metadata.readdy.position
             front_matter = "---\ntitle: " + title + "\ncategory: " + category + "\nposition: " + position + "\n---\n"
-            print("prepending the following front matter", front_matter)
-            filename_as_html = os.path.splitext(filename)[0]+'.html'
+            print("prepending the following front matter\n", front_matter)
+            filename_as_html = os.path.splitext(filename)[0] + ".html"
             with open(filename_as_html, "r") as content_file:
                 origin = content_file.read()
 

--- a/readdy_documentation/_config.yml
+++ b/readdy_documentation/_config.yml
@@ -27,9 +27,9 @@ collections:
     output: true
     permalink: /:collection/:path
 defaults:
-  -
-    scope:
+  - scope:
+      path: ""
       type: "tutorials"
     values:
-      layout: "page"
+      layout: "notebook"
       title: "defaulttitle"

--- a/readdy_documentation/_includes/head.html
+++ b/readdy_documentation/_includes/head.html
@@ -23,7 +23,9 @@
       "HTML-CSS": { preferredFont: "TeX", availableFonts: ["STIX","TeX"] }
     });
     </script>
-    <script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML" type="text/javascript"></script>
+    <script type="text/javascript" async
+            src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML">
+    </script>
 
     <link rel="icon" type="image/png" href="{{ site.baseurl }}/assets/icon_black_32px.png">
 

--- a/readdy_documentation/_layouts/notebook.html
+++ b/readdy_documentation/_layouts/notebook.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+{% include head.html %}
+
+<body>
+{% include side.html %}
+<div class="main-container">
+    <div class="main notebook">
+        <article>
+            <div class="docpage-heading"><h1>{{ page.title }}</h1></div>
+
+            {{ content
+            | replace: '<li>[ ]', '<li class="box task-list-item"><input type="checkbox" class="task-list-item-checkbox" disabled>'
+            | replace: '<li>[x]', '<li class="box_done task-list-item"><input type="checkbox" class="task-list-item-checkbox" value="on" disabled checked>'
+            }}
+        </article>
+        <div class="foot">
+            {% include foot.html %}
+        </div>
+    </div>
+</div>
+</body>
+
+</html>

--- a/readdy_documentation/_sass/_main.scss
+++ b/readdy_documentation/_sass/_main.scss
@@ -45,6 +45,24 @@
   }
 }
 
+// when the page is a notebook, make it wider to contain the input prompts
+
+.notebook {
+  max-width: 40rem;
+}
+
+@media (min-width: $transition-to-side) {
+  .notebook {
+    max-width: 60rem;
+  }
+}
+
+@media (min-width: $transition-to-large) {
+  .notebook {
+    max-width: 60rem;
+  }
+}
+
 // headings
 .main h1, .main h2, .main h3, .main h4, .main h5 {
   font-weight: normal;

--- a/readdy_documentation/_sass/_syntax-highlighting.scss
+++ b/readdy_documentation/_sass/_syntax-highlighting.scss
@@ -14,15 +14,29 @@
 
 .input_prompt {
   float: left;
+  margin-top: 0.7rem;
+  font-family: $mono-font;
+  font-size: 12px;
+  color: #0086B3;
 }
 
 .inner_cell {
   overflow: hidden;
-  margin-left: 4em;
+  margin-left: 4rem;
 }
 
-.output_area {
-  margin-left: 4em;
+.output_prompt {
+  color: #cd6e75;
+  float: left;
+  font-family: $mono-font;
+  font-size: 12px;
+}
+
+.output_subarea {
+  margin-left: 4rem;
+  margin-top: 0.7rem;
+  font-family: $mono-font;
+  font-size: 12px;
 }
 
 pre {

--- a/readdy_documentation/_sass/_syntax-highlighting.scss
+++ b/readdy_documentation/_sass/_syntax-highlighting.scss
@@ -1,4 +1,36 @@
 /**
+ * Define styles for html-converted notebooks
+ */
+
+.cell {
+  margin-top: 1em;
+  margin-bottom: 1em;
+}
+
+.input {
+  overflow: hidden;
+  width: auto;
+}
+
+.input_prompt {
+  float: left;
+}
+
+.inner_cell {
+  overflow: hidden;
+  margin-left: 4em;
+}
+
+.output_area {
+  margin-left: 4em;
+}
+
+pre {
+  font-family: $mono-font;
+  margin: 0;
+}
+
+/**
  * Syntax highlighting styles
  */
 
@@ -15,13 +47,16 @@ code {
 }
 
 .highlight {
+  font-family: $mono-font;
+  font-size: 12px;
+
   color: #282828;
   background: $code-background-color;
   position: relative;
   overflow-x: auto;
   padding: 0.7rem;
   border: $code-border-color solid 1px;
-  line-height: 1;
+  line-height: normal;
 
   .c {
     color: #998;
@@ -120,19 +155,19 @@ code {
   }
   // Generic.Traceback
   .kc {
-    font-weight: bold
+    color: #096e65;
   }
   // Keyword.Constant
   .kd {
-    font-weight: bold
+    //font-weight: bold
   }
   // Keyword.Declaration
   .kp {
-    font-weight: bold
+    //font-weight: bold
   }
   // Keyword.Pseudo
   .kr {
-    font-weight: bold
+    //font-weight: bold
   }
   // Keyword.Reserved
   .kt {
@@ -176,7 +211,7 @@ code {
   // Name.Exception
   .nf {
     color: #900;
-    font-weight: bold
+    //font-weight: bold
   }
   // Name.Function
   .nn {
@@ -216,35 +251,35 @@ code {
   }
   // Literal.Number.Oct
   .sb {
-    color: #d14
+    color: #cd6e75
   }
   // Literal.String.Backtick
   .sc {
-    color: #d14
+    color: #cd6e75
   }
   // Literal.String.Char
   .sd {
-    color: #d14
+    color: #cd6e75
   }
   // Literal.String.Doc
   .s2 {
-    color: #d14
+    color: #cd6e75
   }
   // Literal.String.Double
   .se {
-    color: #d14
+    color: #cd6e75
   }
   // Literal.String.Escape
   .sh {
-    color: #d14
+    color: #cd6e75
   }
   // Literal.String.Heredoc
   .si {
-    color: #d14
+    color: #cd6e75
   }
   // Literal.String.Interpol
   .sx {
-    color: #d14
+    color: #cd6e75
   }
   // Literal.String.Other
   .sr {
@@ -252,7 +287,7 @@ code {
   }
   // Literal.String.Regex
   .s1 {
-    color: #d14
+    color: #cd6e75
   }
   // Literal.String.Single
   .ss {
@@ -279,4 +314,10 @@ code {
     color: #099
   }
   // Literal.Number.Integer.Long
+}
+
+@media(min-width: $transition-to-large) {
+  .highlight {
+    font-size: 13px;
+  }
 }


### PR DESCRIPTION
Ipython notebooks (usually fetched from the `readdy/readdy_tutorials` repo) are converted to basic html now, instead of markdown. This way the typical `In[1]` and `Out[1]` prompts are in place and can be styled. 
The notebooks need to have certain metadata, that determine the
- title, displayed on the webpage and navigation
- category, which will be used to distinguish "demonstration", "verfication" and "advanced" tutorials
- position, which corresponds to the position in the navigation

An example is
```js
"metadata": {
    "readdy" : {
         "title": "Internal API",
         "category": "demonstration",
         "position": "1"
    },
    ...
}
```

The metadata is obtained from the notebook and prepended to the converted html as a yaml front-matter, which then gets read by jekyll.