### PR TITLE
Push output to organization page

### DIFF
--- a/build_website.sh
+++ b/build_website.sh
@@ -92,7 +92,7 @@ function setup_output_repo {
   git init
   git config user.name "Christoph Froehner"
   git config user.email "chrisfroe@users.noreply.github.com"
-  git remote add upstream "https://$GH_TOKEN@github.com/readdy/readdy_documentation.git" > /dev/null 2>&1
+  git remote add upstream "https://$GH_TOKEN@github.com/readdy/readdy.github.io.git" > /dev/null 2>&1
   git fetch upstream
   git checkout --orphan workbranch
   git reset --hard
@@ -104,7 +104,7 @@ function deploy {
   touch .
   git add -A .
   git commit -m "github pages"
-  git push -q -f upstream workbranch:gh-pages > /dev/null 2>&1
+  git push -q -f upstream workbranch:master > /dev/null 2>&1
 }
 
 set_this_up

--- a/readdy_documentation/_config.yml
+++ b/readdy_documentation/_config.yml
@@ -2,7 +2,7 @@ title: ReaDDy documentation
 email: readdyadmin@lists.fu-berlin.de
 description: >
   Documentation of ReaDDy, the particle-based reaction-diffusion simulator
-baseurl: /readdy_documentation
+baseurl:
 url: https://readdy.github.io
 github_username: readdy
 sass:

--- a/readdy_documentation/_layouts/homepage.html
+++ b/readdy_documentation/_layouts/homepage.html
@@ -2,6 +2,6 @@
 layout: default
 ---
 
-<div class="centered"><h1>ReaDDy <br><u>Rea</u>ction <u>D</u>iffusion <u>Dy</u>namics</h1></div>
+<div class="centered"><h1 style="border-bottom: none">ReaDDy <br><u>Rea</u>ction <u>D</u>iffusion <u>Dy</u>namics</h1></div>
 
     {{ content }}

--- a/readdy_documentation/_sass/_main.scss
+++ b/readdy_documentation/_sass/_main.scss
@@ -50,10 +50,6 @@
   }
 }
 
-.main p {
-  margin-bottom: 1.8rem;
-}
-
 .main ul {
   margin-bottom: 1.8rem;
 }
@@ -75,7 +71,7 @@
 .main h2 {
   font-size: 1.5rem;
   margin-bottom: 1.2rem;
-  margin-top: 0;
+  margin-top: 0.5rem;
 }
 
 .main h3 {


### PR DESCRIPTION
- Push html output to `readdy/readdy.github.io:master` instead of `readdy/readdy_documentation:gh-pages`. Thus the webpage will end up under the url `https://readdy.github.io` instead of `https://readdy.github.io/readdy_documentation`
- Minor layout fixes